### PR TITLE
add dump-external links command

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -82,7 +82,6 @@ pub struct LocalLinksOnly<C> {
 
 pub fn canonicalize_local_link<'a, P>(arena: &Bump, mut link: Link<'a, P>) -> Option<Link<'a, P>> {
     if let Link::Uses(ref mut used_link) = link {
-        dbg!(&used_link.href);
         if is_external_link(&used_link.href.0.as_bytes()) {
             return None;
         }

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -150,7 +150,6 @@ mod test_push_and_canonicalize {
         push_and_canonicalize(&mut base, path);
         assert_eq!(base, "http://foo.com");
     }
-
 }
 
 #[inline]
@@ -419,8 +418,8 @@ fn test_html_parsing_malformed_script() {
 fn test_document_links() {
     use bumpalo::Bump;
 
-    use crate::paragraph::ParagraphHasher;
     use crate::collector::canonicalize_local_link;
+    use crate::paragraph::ParagraphHasher;
 
     let doc = Document::new(
         Path::new("public/"),
@@ -479,7 +478,9 @@ fn test_document_links() {
     let arena = Bump::new();
 
     assert_eq!(
-        &links.filter_map(|x| canonicalize_local_link(&arena, x)).collect::<Vec<_>>(),
+        &links
+            .filter_map(|x| canonicalize_local_link(&arena, x))
+            .collect::<Vec<_>>(),
         &[
             used_link("platforms/ruby"),
             used_link("platforms/perl"),

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -9,7 +9,6 @@ use std::str;
 use std::sync::Arc;
 
 use anyhow::Error;
-use bumpalo::Bump;
 use bumpalo::collections::String as BumpString;
 use bumpalo::collections::Vec as BumpVec;
 use html5gum::{IoReader, Tokenizer};
@@ -418,6 +417,8 @@ fn test_html_parsing_malformed_script() {
 
 #[test]
 fn test_document_links() {
+    use bumpalo::Bump;
+
     use crate::paragraph::ParagraphHasher;
     use crate::collector::canonicalize_local_link;
 

--- a/src/html/parser.rs
+++ b/src/html/parser.rs
@@ -232,4 +232,3 @@ where
     fn set_doctype_system_identifier(&mut self, _: &[u8]) {}
     fn set_force_quirks(&mut self) {}
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod collector;
 mod html;
 mod markdown;
 mod paragraph;
+mod urls;
 
 use std::cmp;
 use std::collections::{BTreeMap, BTreeSet};
@@ -19,8 +20,6 @@ use rayon::prelude::*;
 use collector::{BrokenLinkCollector, LocalLinksOnly, LinkCollector, UsedLinkCollector};
 use html::{DefinedLink, Document, DocumentBuffers, Link};
 use paragraph::{DebugParagraphWalker, NoopParagraphWalker, ParagraphHasher, ParagraphWalker};
-
-use crate::html::is_external_url;
 
 static MARKDOWN_FILES: &[&str] = &["md", "mdx"];
 static HTML_FILES: &[&str] = &["htm", "html"];
@@ -377,17 +376,13 @@ fn dump_external_links(base_path: PathBuf) -> Result<(), Error> {
 
 
     for used_link in used_links {
+        external_link_count += 1;
 
-        // check if the used link is external
-        if is_external_url(used_link.href.as_str()) {
-            external_link_count += 1;
+        let external_links_at_path = external_links
+            .entry(used_link.path.clone())
+            .or_insert_with(|| BTreeSet::new());
 
-            let external_links_at_path = external_links
-                .entry(used_link.path.clone())
-                .or_insert_with(|| BTreeSet::new());
-
-            external_links_at_path.insert(&used_link.href);
-        }
+        external_links_at_path.insert(&used_link.href);
     }
 
     for (filepath, external_links_by_path) in external_links {

--- a/src/main.rs
+++ b/src/main.rs
@@ -551,7 +551,7 @@ fn extract_markdown_paragraphs<P: ParagraphWalker>(
 fn match_all_paragraphs(base_path: PathBuf, sources_path: PathBuf) -> Result<(), Error> {
     println!("Reading files");
     let html_result =
-        extract_html_links::<UsedLinkCollector<_>, ParagraphHasher>(&base_path, true)?;
+        extract_html_links::<LocalLinksOnly<UsedLinkCollector<_>>, ParagraphHasher>(&base_path, true)?;
 
     println!("Reading source files");
     let paragraps_to_sourcefile = extract_markdown_paragraphs::<ParagraphHasher>(&sources_path)?;
@@ -564,7 +564,7 @@ fn match_all_paragraphs(base_path: PathBuf, sources_path: PathBuf) -> Result<(),
     let mut link_single_source = 0;
     // We only care about HTML's used links because paragraph matching is exclusively for error
     // messages that point to the broken link.
-    for link in &html_result.collector.used_links {
+    for link in &html_result.collector.collector.used_links {
         total_links += 1;
 
         let paragraph = match link.paragraph {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use jwalk::WalkDirGeneric;
 use markdown::DocumentSource;
 use rayon::prelude::*;
 
-use collector::{BrokenLinkCollector, LocalLinksOnly, LinkCollector, UsedLinkCollector};
+use collector::{BrokenLinkCollector, LinkCollector, LocalLinksOnly, UsedLinkCollector};
 use html::{DefinedLink, Document, DocumentBuffers, Link};
 use paragraph::{DebugParagraphWalker, NoopParagraphWalker, ParagraphHasher, ParagraphWalker};
 
@@ -89,9 +89,7 @@ enum Subcommand {
     /// Dump out a list and count of _external_ links.  hyperlink does not check external links,
     /// but this subcommand can be used to get a summary of the external links that exist in your
     /// site.
-    DumpExternalLinks {
-        base_path: PathBuf,
-    },
+    DumpExternalLinks { base_path: PathBuf },
 }
 
 fn main() -> Result<(), Error> {
@@ -125,7 +123,7 @@ fn main() -> Result<(), Error> {
         }
         Some(Subcommand::DumpExternalLinks { base_path }) => {
             return dump_external_links(base_path);
-        },
+        }
         None => {}
     }
 
@@ -161,7 +159,8 @@ where
 {
     println!("Reading files");
 
-    let html_result = extract_html_links::<LocalLinksOnly<BrokenLinkCollector<_>>, P>(&base_path, check_anchors)?;
+    let html_result =
+        extract_html_links::<LocalLinksOnly<BrokenLinkCollector<_>>, P>(&base_path, check_anchors)?;
 
     let used_links_len = html_result.collector.collector.used_links_count();
     println!(
@@ -362,18 +361,15 @@ fn dump_external_links(base_path: PathBuf) -> Result<(), Error> {
 
     println!(
         "Checking {} links from {} files ({} documents)",
-        html_result.collector.used_links.len(), html_result.file_count, html_result.documents_count,
+        html_result.collector.used_links.len(),
+        html_result.file_count,
+        html_result.documents_count,
     );
 
     let mut external_links = BTreeMap::new();
     let mut external_link_count: u32 = 0;
 
-    let used_links = html_result
-        .collector
-        .used_links
-        .iter()
-        .peekable();
-
+    let used_links = html_result.collector.used_links.iter().peekable();
 
     for used_link in used_links {
         external_link_count += 1;
@@ -550,8 +546,9 @@ fn extract_markdown_paragraphs<P: ParagraphWalker>(
 
 fn match_all_paragraphs(base_path: PathBuf, sources_path: PathBuf) -> Result<(), Error> {
     println!("Reading files");
-    let html_result =
-        extract_html_links::<LocalLinksOnly<UsedLinkCollector<_>>, ParagraphHasher>(&base_path, true)?;
+    let html_result = extract_html_links::<LocalLinksOnly<UsedLinkCollector<_>>, ParagraphHasher>(
+        &base_path, true,
+    )?;
 
     println!("Reading source files");
     let paragraps_to_sourcefile = extract_markdown_paragraphs::<ParagraphHasher>(&sources_path)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,8 @@ use collector::{BrokenLinkCollector, LinkCollector, UsedLinkCollector};
 use html::{DefinedLink, Document, DocumentBuffers, Link};
 use paragraph::{DebugParagraphWalker, NoopParagraphWalker, ParagraphHasher, ParagraphWalker};
 
+use crate::html::is_external_url;
+
 static MARKDOWN_FILES: &[&str] = &["md", "mdx"];
 static HTML_FILES: &[&str] = &["htm", "html"];
 
@@ -82,6 +84,10 @@ enum Subcommand {
         base_path: PathBuf,
         sources_path: PathBuf,
     },
+
+    DumpExternalLinks {
+        base_path: PathBuf,
+    },
 }
 
 fn main() -> Result<(), Error> {
@@ -111,6 +117,9 @@ fn main() -> Result<(), Error> {
         }) => {
             return match_all_paragraphs(base_path, sources_path);
         }
+        Some(Subcommand::DumpExternalLinks { base_path }) => {
+            return dump_external_links(base_path);
+        },
         None => {}
     }
 
@@ -339,6 +348,57 @@ fn dump_paragraphs(path: PathBuf) -> Result<(), Error> {
             println!("{}", paragraph);
         }
     }
+
+    Ok(())
+}
+
+fn dump_external_links(base_path: PathBuf) -> Result<(), Error> {
+    println!("Reading files");
+    let html_result =
+        extract_html_links::<UsedLinkCollector<_>, NoopParagraphWalker>(&base_path, true, false)?;
+
+    println!(
+        "Checking {} links from {} files ({} documents)",
+        html_result.collector.used_links.len(), html_result.file_count, html_result.documents_count,
+    );
+
+    let mut external_links = BTreeMap::new();
+    let mut external_link_count: u32 = 0;
+
+    let used_links = html_result
+        .collector
+        .used_links
+        .iter()
+        .peekable();
+
+
+    for used_link in used_links {
+
+        // check if the used link is external
+        if is_external_url(used_link.href.as_str()) {
+            external_link_count += 1;
+
+            let external_links_at_path = external_links
+                .entry(used_link.path.clone())
+                .or_insert_with(|| BTreeSet::new());
+
+            external_links_at_path.insert(&used_link.href);
+        }
+    }
+
+    for (filepath, external_links_by_path) in external_links {
+        println!("{}", filepath.display());
+
+        for href in &external_links_by_path {
+            println!("  info: external link {}", href);
+        }
+
+        println!();
+    }
+
+    println!("Found {} external links", external_link_count);
+
+    mem::forget(html_result);
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,9 @@ enum Subcommand {
         sources_path: PathBuf,
     },
 
+    /// Dump out a list and count of _external_ links.  hyperlink does not check external links,
+    /// but this subcommand can be used to get a summary of the external links that exist in your
+    /// site.
     DumpExternalLinks {
         base_path: PathBuf,
     },

--- a/src/urls.rs
+++ b/src/urls.rs
@@ -1,0 +1,45 @@
+#[inline]
+pub fn is_external_link(url: &[u8]) -> bool {
+    // check if url is empty
+    let first_char = match url.first() {
+        Some(x) => x,
+        None => return false,
+    };
+
+    // protocol-relative URL
+    if url.starts_with(b"//") {
+        return true;
+    }
+
+    // check if string before first : is a valid URL scheme
+    // see RFC 2396, Appendix A for what constitutes a valid scheme
+
+    if !matches!(first_char, b'a'..=b'z' | b'A'..=b'Z') {
+        return false;
+    }
+
+    for c in &url[1..] {
+        match c {
+            b'a'..=b'z' => (),
+            b'A'..=b'Z' => (),
+            b'0'..=b'9' => (),
+            b'+' => (),
+            b'-' => (),
+            b'.' => (),
+            b':' => return true,
+            _ => return false,
+        }
+    }
+
+    false
+}
+
+#[test]
+fn test_is_bad_schema() {
+    assert!(is_external_link(b"//"));
+    assert!(!is_external_link(b""));
+    assert!(!is_external_link(b"http"));
+    assert!(is_external_link(b"http:"));
+    assert!(is_external_link(b"http:/"));
+    assert!(!is_external_link(b"http/"));
+}


### PR DESCRIPTION
see #158 and #5 

- add `dump-external-links` subcommand
- add description for dump-external-links subcommand
- remove is_external
- fix match-all-paragraphs
- fmt
- remove dbg
- simplify output format
