### PR TITLE
Remove unused use of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,5 +42,4 @@ jobs:
       - run: cargo test
       - uses: clechasseur/rs-clippy-check@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features


### PR DESCRIPTION
This PR bumps dependencies to their latest versions.