### PR TITLE
Harden installer: verify via GitHub build attestation instead of curl | sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,10 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
+    permissions:
+      "attestations": "write"
+      "contents": "read"
+      "id-token": "write"
     steps:
       - name: enable windows longpaths
         run: |
@@ -144,6 +148,10 @@ jobs:
           # Actually do builds and make zips and whatnot
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
+      - name: Attest
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "target/distrib/*${{ join(matrix.targets, ', ') }}*"
       - id: cargo-dist
         name: Post-build
         # We force bash here just because github makes it really hard to get values up

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,10 +112,6 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
-    permissions:
-      "attestations": "write"
-      "contents": "read"
-      "id-token": "write"
     steps:
       - name: enable windows longpaths
         run: |
@@ -148,10 +144,6 @@ jobs:
           # Actually do builds and make zips and whatnot
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
-      - name: Attest
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: "target/distrib/*${{ join(matrix.targets, ', ') }}*"
       - id: cargo-dist
         name: Post-build
         # We force bash here just because github makes it really hard to get values up
@@ -232,6 +224,10 @@ jobs:
     runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
+    permissions:
+      "attestations": "write"
+      "contents": "write"
+      "id-token": "write"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -274,6 +270,11 @@ jobs:
         run: |
           # Remove the granular manifests
           rm -f artifacts/*-dist-manifest.json
+      - name: Attest
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            artifacts/*
       - name: Create GitHub Release
         env:
           PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,29 @@ A command-line tool to find broken links in your static site.
     args: public/ --sources src/
 ```
 
+The action downloads the prebuilt binary and verifies it against its [GitHub
+build
+attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds)
+before running (see #198). Verification uses the `gh` CLI: on GitHub-hosted
+runners `gh` is present, so the check runs automatically. On runners without
+`gh` — e.g. [Forgejo](https://forgejo.org/) or other non-GitHub CI —
+verification is skipped with a warning so the action still works.
+
+Two environment variables override this:
+
+* `HYPERLINK_SKIP_ATTESTATION=1` skips verification entirely, even when `gh` is
+  available.
+* `HYPERLINK_FORCE_ATTESTATION=1` requires verification and fails when `gh` is
+  missing.
+
+```yaml
+- uses: untitaker/hyperlink@0.2.1
+  env:
+    HYPERLINK_SKIP_ATTESTATION: "1"
+  with:
+    args: public/ --sources src/
+```
+
 ### NPM
 
 ```bash

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -23,3 +23,9 @@ install-updater = false
 # release artifacts, recorded in GitHub's transparency log so consumers can
 # verify them independently of the (mutable) release assets — see #198.
 github-attestations = true
+# Attest in the "host" phase, not the default "build-local-artifacts". The
+# default only attests the per-target binaries; the installer scripts and
+# checksums are *global* artifacts assembled in the host phase, so attesting
+# there is what gives hyperlink-installer.sh (the file scripts/install.sh
+# verifies) an attestation at all.
+github-attestations-phase = "host"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -19,13 +19,7 @@ npm-scope = "@untitaker"
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
-# Emit GitHub build attestations (Sigstore-backed SLSA provenance) for
-# release artifacts, recorded in GitHub's transparency log so consumers can
-# verify them independently of the (mutable) release assets — see #198.
+# Attest release artifacts (see #198); "host" phase so the installer — a global
+# artifact — is covered, not just the per-target binaries.
 github-attestations = true
-# Attest in the "host" phase, not the default "build-local-artifacts". The
-# default only attests the per-target binaries; the installer scripts and
-# checksums are *global* artifacts assembled in the host phase, so attesting
-# there is what gives hyperlink-installer.sh (the file scripts/install.sh
-# verifies) an attestation at all.
 github-attestations-phase = "host"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -19,3 +19,7 @@ npm-scope = "@untitaker"
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
+# Emit GitHub build attestations (Sigstore-backed SLSA provenance) for
+# release artifacts, recorded in GitHub's transparency log so consumers can
+# verify them independently of the (mutable) release assets — see #198.
+github-attestations = true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,8 +5,10 @@ tag="`grep 'version = ' Cargo.toml | head -1 | cut -d'"' -f2`"
 echo "downloading hyperlink $tag"
 
 # Download the installer to a file and verify it against its GitHub build
-# attestation before running it (see #198). Set HYPERLINK_SKIP_ATTESTATION=1 to
-# skip — e.g. on runners without `gh` / a GitHub token, such as Forgejo.
+# attestation before running it (see #198). Verification needs the `gh` CLI; when
+# `gh` is absent (e.g. Forgejo or other non-GitHub CI) the check is skipped with
+# a warning. Set HYPERLINK_SKIP_ATTESTATION=1 to skip it entirely, or
+# HYPERLINK_FORCE_ATTESTATION=1 to fail instead of skipping when `gh` is missing.
 installer="`mktemp`"
 trap 'rm -f "$installer"' EXIT
 
@@ -14,13 +16,18 @@ curl --proto '=https' --tlsv1.2 -LsSf \
     "https://github.com/untitaker/hyperlink/releases/download/$tag/hyperlink-installer.sh" \
     -o "$installer"
 
-if [ -z "$HYPERLINK_SKIP_ATTESTATION" ]; then
+if [ -n "$HYPERLINK_SKIP_ATTESTATION" ]; then
+    echo "hyperlink: HYPERLINK_SKIP_ATTESTATION set, skipping attestation verification" >&2
+elif command -v gh >/dev/null 2>&1; then
     # --signer-workflow pins the producing workflow, not just the repo.
     gh attestation verify "$installer" \
         --repo untitaker/hyperlink \
         --signer-workflow untitaker/hyperlink/.github/workflows/release.yml
+elif [ -n "$HYPERLINK_FORCE_ATTESTATION" ]; then
+    echo "hyperlink: HYPERLINK_FORCE_ATTESTATION is set but 'gh' is not installed; cannot verify attestation" >&2
+    exit 1
 else
-    echo "hyperlink: HYPERLINK_SKIP_ATTESTATION set, skipping attestation check" >&2
+    echo "hyperlink: 'gh' not found, skipping attestation verification (set HYPERLINK_FORCE_ATTESTATION=1 to require it)" >&2
 fi
 
 sh "$installer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,4 +4,21 @@ tag="`grep 'version = ' Cargo.toml | head -1 | cut -d'"' -f2`"
 
 echo "downloading hyperlink $tag"
 
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/untitaker/hyperlink/releases/download/$tag/hyperlink-installer.sh | sh
+# Download the installer to a file (rather than piping straight into sh) and
+# verify it against its GitHub build attestation before running it. The
+# attestation is Sigstore-backed and lives in GitHub's transparency log, so —
+# unlike a checksum shipped beside the script in the same mutable release — it
+# cannot be swapped together with the artifact. See #198.
+#
+# Requires `gh` (preinstalled on GitHub runners) and a token in GH_TOKEN /
+# GITHUB_TOKEN. Attestations exist for releases built after
+# `github-attestations` was enabled in dist-workspace.toml.
+installer="`mktemp`"
+curl --proto '=https' --tlsv1.2 -LsSf \
+    "https://github.com/untitaker/hyperlink/releases/download/$tag/hyperlink-installer.sh" \
+    -o "$installer"
+
+gh attestation verify "$installer" --repo untitaker/hyperlink
+
+sh "$installer"
+rm -f "$installer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,11 +14,19 @@ echo "downloading hyperlink $tag"
 # GITHUB_TOKEN. Attestations exist for releases built after
 # `github-attestations` was enabled in dist-workspace.toml.
 installer="`mktemp`"
+# Always clean up the temp file, including when `set -e` aborts on a failed
+# verification below.
+trap 'rm -f "$installer"' EXIT
+
 curl --proto '=https' --tlsv1.2 -LsSf \
     "https://github.com/untitaker/hyperlink/releases/download/$tag/hyperlink-installer.sh" \
     -o "$installer"
 
-gh attestation verify "$installer" --repo untitaker/hyperlink
+# Pin the producing workflow, not just the repo: only an attestation minted by
+# the real release workflow is accepted, so a different (or compromised)
+# workflow in the same repo cannot mint one that passes.
+gh attestation verify "$installer" \
+    --repo untitaker/hyperlink \
+    --signer-workflow untitaker/hyperlink/.github/workflows/release.yml
 
 sh "$installer"
-rm -f "$installer"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,29 +4,23 @@ tag="`grep 'version = ' Cargo.toml | head -1 | cut -d'"' -f2`"
 
 echo "downloading hyperlink $tag"
 
-# Download the installer to a file (rather than piping straight into sh) and
-# verify it against its GitHub build attestation before running it. The
-# attestation is Sigstore-backed and lives in GitHub's transparency log, so —
-# unlike a checksum shipped beside the script in the same mutable release — it
-# cannot be swapped together with the artifact. See #198.
-#
-# Requires `gh` (preinstalled on GitHub runners) and a token in GH_TOKEN /
-# GITHUB_TOKEN. Attestations exist for releases built after
-# `github-attestations` was enabled in dist-workspace.toml.
+# Download the installer to a file and verify it against its GitHub build
+# attestation before running it (see #198). Set HYPERLINK_SKIP_ATTESTATION=1 to
+# skip — e.g. on runners without `gh` / a GitHub token, such as Forgejo.
 installer="`mktemp`"
-# Always clean up the temp file, including when `set -e` aborts on a failed
-# verification below.
 trap 'rm -f "$installer"' EXIT
 
 curl --proto '=https' --tlsv1.2 -LsSf \
     "https://github.com/untitaker/hyperlink/releases/download/$tag/hyperlink-installer.sh" \
     -o "$installer"
 
-# Pin the producing workflow, not just the repo: only an attestation minted by
-# the real release workflow is accepted, so a different (or compromised)
-# workflow in the same repo cannot mint one that passes.
-gh attestation verify "$installer" \
-    --repo untitaker/hyperlink \
-    --signer-workflow untitaker/hyperlink/.github/workflows/release.yml
+if [ -z "$HYPERLINK_SKIP_ATTESTATION" ]; then
+    # --signer-workflow pins the producing workflow, not just the repo.
+    gh attestation verify "$installer" \
+        --repo untitaker/hyperlink \
+        --signer-workflow untitaker/hyperlink/.github/workflows/release.yml
+else
+    echo "hyperlink: HYPERLINK_SKIP_ATTESTATION set, skipping attestation check" >&2
+fi
 
 sh "$installer"


### PR DESCRIPTION
## What

Addresses #198 — verify the installer against a GitHub build attestation instead of `curl … | sh`.

- Enable `github-attestations = true` in `dist-workspace.toml` → each release artifact gets a Sigstore-backed SLSA attestation recorded in GitHub's transparency log.
- `scripts/install.sh` downloads `hyperlink-installer.sh` to a file and runs `gh attestation verify` on it before executing.

## Why

Per the discussion in #198: a checksum shipped beside the script in the same (mutable) release proves nothing — both can be swapped together. A GitHub attestation lives in the transparency log, independent of the release assets, so it can't.

## Draft / open questions

- **Token:** `gh attestation verify` needs `GH_TOKEN`/`GITHUB_TOKEN` in the step env — may need documenting for consumers (or fetching the attestation bundle offline).
- **Effective from the next release:** attestations only exist for releases built after `github-attestations` is enabled.
- **Attested artifacts:** confirm `hyperlink-installer.sh` itself is attested (vs only the archives); may need a `github-attestations-filters` tweak.

Opened as a draft for discussion — happy to iterate.

Generated-by: Claude Opus 4.8 (1M context)
